### PR TITLE
WordPress 4.7 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Add 2 PHP functions for WP Filter API, it's allow to remove filter/action on hoo
 
 **These functions are very useful for removing filters and actions from plugin not very well developed!**
 
-## Remove filters with method name only 
+## Remove filters with method name only
 
 `remove_filters_with_method_name( $hook_name = '', $method_name = '', $priority = 0 );`
 
@@ -20,7 +20,7 @@ Allow to remove method for an hook when, it's a class method used and class don'
 ## Usage
 
 ### Example :
-	
+
 ```php
 // First sample
 class MyClassA {
@@ -65,7 +65,7 @@ This call will remove the 2 filters for classes MyClassA and MyClassB.
 The second method, `remove_filters_for_anonymous_class();`, is more accurate because it is necessary to specify both the name of the method but also the name of the PHP class.
 
 ```php
-remove_filters_for_anonymous_class( 'wp_footer', 'MyClassB', my_action', 10 );
+remove_filters_for_anonymous_class( 'wp_footer', 'MyClassB', 'my_action', 10 );
 ```
 
 This call will only remove the filter for the class MyClassB.

--- a/wp-filters-extras.php
+++ b/wp-filters-extras.php
@@ -10,7 +10,7 @@ Author URI: http://www.beapi.fr
 Copyright 2012 Amaury Balmer - amaury@beapi.fr
 
 This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License, version 2, as 
+it under the terms of the GNU General Public License, version 2, as
 published by the Free Software Foundation.
 
 This program is distributed in the hope that it will be useful,
@@ -28,23 +28,29 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 function remove_filters_with_method_name( $hook_name = '', $method_name = '', $priority = 0 ) {
 	global $wp_filter;
-	
+
 	// Take only filters on right hook name and priority
 	if ( !isset($wp_filter[$hook_name][$priority]) || !is_array($wp_filter[$hook_name][$priority]) )
 		return false;
-	
+
 	// Loop on filters registered
 	foreach( (array) $wp_filter[$hook_name][$priority] as $unique_id => $filter_array ) {
 		// Test if filter is an array ! (always for class/method)
 		if ( isset($filter_array['function']) && is_array($filter_array['function']) ) {
 			// Test if object is a class and method is equal to param !
 			if ( is_object($filter_array['function'][0]) && get_class($filter_array['function'][0]) && $filter_array['function'][1] == $method_name ) {
-				unset($wp_filter[$hook_name][$priority][$unique_id]);
+			    // Test for WordPress >= 4.7 WP_Hook class (https://make.wordpress.org/core/2016/09/08/wp_hook-next-generation-actions-and-filters/)
+			    if( is_a( $wp_filter[$hook_name], 'WP_Hook' ) ) {
+			        unset( $wp_filter[$hook_name]->callbacks[$priority][$unique_id] );
+			    }
+			    else {
+				    unset($wp_filter[$hook_name][$priority][$unique_id]);
+			    }
 			}
 		}
-		
+
 	}
-	
+
 	return false;
 }
 
@@ -53,22 +59,28 @@ function remove_filters_with_method_name( $hook_name = '', $method_name = '', $p
  */
 function remove_filters_for_anonymous_class( $hook_name = '', $class_name ='', $method_name = '', $priority = 0 ) {
 	global $wp_filter;
-	
+
 	// Take only filters on right hook name and priority
 	if ( !isset($wp_filter[$hook_name][$priority]) || !is_array($wp_filter[$hook_name][$priority]) )
 		return false;
-	
+
 	// Loop on filters registered
 	foreach( (array) $wp_filter[$hook_name][$priority] as $unique_id => $filter_array ) {
 		// Test if filter is an array ! (always for class/method)
 		if ( isset($filter_array['function']) && is_array($filter_array['function']) ) {
 			// Test if object is a class, class and method is equal to param !
 			if ( is_object($filter_array['function'][0]) && get_class($filter_array['function'][0]) && get_class($filter_array['function'][0]) == $class_name && $filter_array['function'][1] == $method_name ) {
-				unset($wp_filter[$hook_name][$priority][$unique_id]);
+			    // Test for WordPress >= 4.7 WP_Hook class (https://make.wordpress.org/core/2016/09/08/wp_hook-next-generation-actions-and-filters/)
+			    if( is_a( $wp_filter[$hook_name], 'WP_Hook' ) ) {
+			        unset( $wp_filter[$hook_name]->callbacks[$priority][$unique_id] );
+			    }
+			    else {
+				    unset($wp_filter[$hook_name][$priority][$unique_id]);
+			    }
 			}
 		}
-		
+
 	}
-	
+
 	return false;
 }


### PR DESCRIPTION
Since new WP_Hook class doesn't allow direct unsetting anymore, I just added a condition to check if we are facing this class in order to use the new unsetting method.
See here: https://make.wordpress.org/core/2016/09/08/wp_hook-next-generation-actions-and-filters/