### PR TITLE
Replacing new hook with old hook.

### DIFF
--- a/wp-filters-extras.php
+++ b/wp-filters-extras.php
@@ -24,9 +24,10 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 /**
- * Allow to remove method for an hook when, it's a class method used and class don't have global for instanciation !
- */
-function remove_filters_with_method_name( $hook_name = '', $method_name = '', $priority = 0 ) {
+* Allow to remove method for an hook when, it's a class method used and class don't have global for instanciation !
+*/
+function remove_filters_with_method_name( $hook_name = '', $method_name = '', $priority = 0 )
+{
 	global $wp_filter;
 
 	// Take only filters on right hook name and priority
@@ -55,9 +56,10 @@ function remove_filters_with_method_name( $hook_name = '', $method_name = '', $p
 }
 
 /**
- * Allow to remove method for an hook when, it's a class method used and class don't have variable, but you know the class name :)
- */
-function remove_filters_for_anonymous_class( $hook_name = '', $class_name = '', $method_name = '', $priority = 0 ) {
+* Allow to remove method for an hook when, it's a class method used and class don't have variable, but you know the class name :)
+*/
+function remove_filters_for_anonymous_class( $hook_name = '', $class_name = '', $method_name = '', $priority = 0 )
+{
 	global $wp_filter;
 
 	// Take only filters on right hook name and priority
@@ -82,5 +84,42 @@ function remove_filters_for_anonymous_class( $hook_name = '', $class_name = '', 
 
 	}
 
+	return false;
+}
+
+/**
+* Allow to replace hook method with new hook, it's a class method used and class don't have variable, but you know the class name :)
+*/
+function replace_filters_for_anonymous_class( $hook_name = '', $new_hook_name = '', $class_name = '', $method_name = '', $priority = 0 )
+{
+	global $wp_filter;
+
+	// Take only filters on right hook name and priority
+	if ( ! isset( $wp_filter[ $hook_name ][ $priority ] ) || ! is_array( $wp_filter[ $hook_name ][ $priority ] ) ) {
+		return false;
+	}
+
+	// if hook doesn't exists then init it.
+	if ( ! isset( $wp_filter[ $new_hook_name ] ) ) {
+		$wp_filter[$new_hook_name] = new WP_Hook();
+	}
+
+	// Loop on filters registered
+	foreach ( (array) $wp_filter[ $hook_name ][ $priority ] as $unique_id => $filter_array ) {
+		// Test if filter is an array ! (always for class/method)
+		if ( isset( $filter_array['function'] ) && is_array( $filter_array['function'] ) ) {
+			// Test if object is a class, class and method is equal to param !
+			if ( is_object( $filter_array['function'][0] ) && get_class( $filter_array['function'][0] ) && get_class( $filter_array['function'][0] ) == $class_name && $filter_array['function'][1] == $method_name ) {
+				// Test for WordPress >= 4.7 WP_Hook class (https://make.wordpress.org/core/2016/09/08/wp_hook-next-generation-actions-and-filters/)
+				if ( is_a( $wp_filter[ $hook_name ], 'WP_Hook' ) ) {
+					$wp_filter[ $new_hook_name ]->callbacks[ $priority ][ $unique_id ] = $wp_filter[ $hook_name ]->callbacks[ $priority ][ $unique_id ];
+					unset( $wp_filter[ $hook_name ]->callbacks[ $priority ][ $unique_id ] );
+				} else {
+					$wp_filter[ $new_hook_name ][ $priority ][ $unique_id ] = $wp_filter[ $hook_name ]->callbacks[ $priority ][ $unique_id ];
+					unset( $wp_filter[ $hook_name ][ $priority ][ $unique_id ] );
+				}
+			}
+		}
+	}
 	return false;
 }


### PR DESCRIPTION
This new function allows copying old hook functions to a new hook.  This function is helpful because as you don't have class object then you're not able to hook that function into a new hook location. So this will clone the old hook data into a new hook and also will remove the old hook data.